### PR TITLE
fixed typo in gcc flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ like:
 
 	gcc minunit_example.c -lrt -lm -o minunit_example
 
-Don't forget to add -ltr for the timer and -lm for linking the function fabs
+Don't forget to add -lrt for the timer and -lm for linking the function fabs
 used in mu_assert_double_eq.
 
 ## Setup and teardown functions


### PR DESCRIPTION
As I was learning how to use your C testing framework, I noticed a difference between the code for compiling and the description of that code. The example code correctly shows the proper flags (-lrt -lm) but the subsequent description show -ltr -lm (unless -ltr refers to something else that I'm not familiar with).

Otherwise, the minunit code works great for me. It was very easy to setup and use.
