### PR TITLE
Include the license directly in minunit.h

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -33,7 +33,10 @@
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
 
 /* Change POSIX C SOURCE version for pure c99 compilers */
+#if !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200112L
+#undef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200112L
+#endif
 
 #include <unistd.h>	/* POSIX flags */
 #include <time.h>	/* clock_gettime(), time() */


### PR DESCRIPTION
This makes it easier to directly use minunit.h, do a simple diff for changes, and still be in compliance with the MIT license. In other words, I'm lazy, and this makes compliance automatic.
