### PR TITLE
added string comparison mu_assert_string_eq

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -43,6 +43,7 @@
 #include <sys/time.h>	/* gethrtime(), gettimeofday() */
 #include <sys/resource.h>
 #include <sys/times.h>
+#include <string.h>
 
 #if defined(__MACH__) && defined(__APPLE__)
 #include <mach/mach.h>
@@ -183,6 +184,29 @@ static void (*minunit_teardown)(void) = NULL;
 	minunit_tmp_r = (result);\
 	if (fabs(minunit_tmp_e-minunit_tmp_r) > MINUNIT_EPSILON) {\
 		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %g expected but was %g", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\
+		minunit_status = 1;\
+		return;\
+	} else {\
+		printf(".");\
+	}\
+)
+
+#define mu_assert_string_eq(expected, result) MU__SAFE_BLOCK(\
+	char* minunit_tmp_e;\
+	char* minunit_tmp_r;\
+	minunit_assert++;\
+	if (!expected) {\
+		minunit_tmp_e = "<null pointer>";\
+	} else {\
+		minunit_tmp_e = (expected);\
+	}\
+	if (!result) {\
+		minunit_tmp_r = "<null pointer>";\
+	} else {\
+		minunit_tmp_r = (result);\
+	}\
+	if(strcmp(minunit_tmp_e, minunit_tmp_r)) {\
+		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: '%s' expected but was '%s'", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\
 		minunit_status = 1;\
 		return;\
 	} else {\

--- a/minunit.h
+++ b/minunit.h
@@ -192,8 +192,8 @@ static void (*minunit_teardown)(void) = NULL;
 )
 
 #define mu_assert_string_eq(expected, result) MU__SAFE_BLOCK(\
-	char* minunit_tmp_e;\
-	char* minunit_tmp_r;\
+	const char* minunit_tmp_e;\
+	const char* minunit_tmp_r;\
 	minunit_assert++;\
 	if (!expected) {\
 		minunit_tmp_e = "<null pointer>";\

--- a/minunit.h
+++ b/minunit.h
@@ -192,18 +192,14 @@ static void (*minunit_teardown)(void) = NULL;
 )
 
 #define mu_assert_string_eq(expected, result) MU__SAFE_BLOCK(\
-	const char* minunit_tmp_e;\
-	const char* minunit_tmp_r;\
+	const char* minunit_tmp_e = expected;\
+	const char* minunit_tmp_r = result;\
 	minunit_assert++;\
-	if (!expected) {\
+	if (!minunit_tmp_e) {\
 		minunit_tmp_e = "<null pointer>";\
-	} else {\
-		minunit_tmp_e = (expected);\
 	}\
-	if (!result) {\
+	if (!minunit_tmp_r) {\
 		minunit_tmp_r = "<null pointer>";\
-	} else {\
-		minunit_tmp_r = (result);\
 	}\
 	if(strcmp(minunit_tmp_e, minunit_tmp_r)) {\
 		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: '%s' expected but was '%s'", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\

--- a/minunit_example.c
+++ b/minunit_example.c
@@ -3,6 +3,7 @@
 static int foo = 0;
 static int bar = 0;
 static double dbar = 0.1;
+static const char* foostring = "Thisstring";
 
 void test_setup() {
 	foo = 7;
@@ -49,6 +50,14 @@ MU_TEST(test_fail) {
 	mu_fail("Fail now!");
 }
 
+MU_TEST(test_string_eq){
+	mu_assert_string_eq("Thisstring", foostring);
+}
+
+MU_TEST(test_string_eq_fail){
+	mu_assert_string_eq("Thatstring", foostring);
+}
+
 
 MU_TEST_SUITE(test_suite) {
 	MU_SUITE_CONFIGURE(&test_setup, &test_teardown);
@@ -62,6 +71,9 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_assert_fail);
 	MU_RUN_TEST(test_assert_int_eq_fail);
 	MU_RUN_TEST(test_assert_double_eq_fail);
+	
+	MU_RUN_TEST(test_string_eq);
+	MU_RUN_TEST(test_string_eq_fail);
 
 	MU_RUN_TEST(test_fail);
 }


### PR DESCRIPTION
string comparison is a very useful feature for many tests.
This particular one also checks if the strings are null, and replaces those with "<null pointer>", before doing the comparison.
