### PR TITLE
Fix apparent bug in "Test runner" code

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -103,7 +103,7 @@ static void (*minunit_teardown)() = NULL;
 
 /*  Test runner */
 #define MU_RUN_TEST(test) MU__SAFE_BLOCK(\
-	if (minunit_real_timer==0 && minunit_real_timer==0) {\
+	if (minunit_real_timer==0 && minunit_proc_timer==0) {\
 		minunit_real_timer = mu_timer_real();\
 		minunit_proc_timer = mu_timer_cpu();\
 	}\


### PR DESCRIPTION
The current test runner code performs the check "minunit_real_timer==0" twice. I assume that it is intended that the second instance should instead read "minunit_proc_timer==0".