### PR TITLE
Enable use of snprintf for Vistual Studio 2015

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -30,7 +30,9 @@
 #if defined(_WIN32)
 #include <Windows.h>
 #define __func__ __FUNCTION__
-#define snprintf _snprintf
+#if defined(_MSC_VER) && _MSC_VER < 1900
+  #define snprintf _snprintf
+#endif
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
 


### PR DESCRIPTION
The code change in PR #9 causes _snprintf to be used for all versions of Visual Studio. However, VS 2015 has support for snprintf, so _snprintf should not be used for this version of VS. Note that _snprintf and snprintf are not the same function as the former does not add a NULL terminator on overflow and is thus less 'safe'. Proposed is to use _snprintf as a fallback only for versions of VS prior to 2015.

I could write a safe alternative for _snprintf for VS 2013 and older, but as more and more people are migrating to 2015 I do not see much value in doing this.