### PR TITLE
Do not #define __func__ for VS2015

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -29,9 +29,9 @@
 
 #if defined(_WIN32)
 #include <Windows.h>
-#define __func__ __FUNCTION__
 #if defined(_MSC_VER) && _MSC_VER < 1900
   #define snprintf _snprintf
+  #define __func__ __FUNCTION__
 #endif
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))


### PR DESCRIPTION
Hope you don't mind me making an few more PRs. As a follow-up on PR #9, __func__ is supported by VS2015 so it only needs to be defined for older versions of VS.