### PR TITLE
Improved report for mu_assert_double_eq

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ equal or show their values as the error message
 
 mu_assert_double_eq(expected, result): it will pass if the two values
 are almost equal or show their values as the error message. The value of
-MINUNIT_EPSILON sets the threshold to determine if the values are close enough.
+MINUNIT_RELEVANT_DIGITS sets the threshold to determine if the values are close enough.
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ equal or show their values as the error message
 
 mu_assert_double_eq(expected, result): it will pass if the two values
 are almost equal or show their values as the error message. The value of
-MINUNIT_RELEVANT_DIGITS sets the threshold to determine if the values are close enough.
+MINUNIT_EPSILON sets the threshold to determine if the values are close enough.
 
 ## Authors
 

--- a/minunit.h
+++ b/minunit.h
@@ -63,8 +63,7 @@
 /*  Maximum length of last message */
 #define MINUNIT_MESSAGE_LEN 1024
 /*  Accuracy with which floats are compared */
-#define MINUNIT_RELEVANT_DIGITS 12
-#define MINUNIT_EPSILON (1E-MINUNIT_RELEVANT_DIGITS)
+#define MINUNIT_EPSILON 1E-12
 
 /*  Misc. counters */
 static int minunit_run = 0;
@@ -187,7 +186,8 @@ static void (*minunit_teardown)() = NULL;
 	minunit_tmp_e = (expected);\
 	minunit_tmp_r = (result);\
 	if (fabs(minunit_tmp_e-minunit_tmp_r) > MINUNIT_EPSILON) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, MINUNIT_RELEVANT_DIGITS, minunit_tmp_e, MINUNIT_RELEVANT_DIGITS, minunit_tmp_r);\
+		int minunit_significant_figures = 1 - log10(MINUNIT_EPSILON);\
+		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, minunit_significant_figures, minunit_tmp_e, minunit_significant_figures, minunit_tmp_r);\
 		minunit_status = 1;\
 		return;\
 	} else {\

--- a/minunit.h
+++ b/minunit.h
@@ -62,10 +62,9 @@
 
 /*  Maximum length of last message */
 #define MINUNIT_MESSAGE_LEN 1024
-/*  Accuracy with which floats are compared ( threshold is 10^(-MINUNIT_EPSILON) ) */
-#define MINUNIT_EPSILON 12
-/* Avoid use of pow() function */
-#define PMIN10(X) (1e##-X)
+/*  Accuracy with which floats are compared */
+#define MINUNIT_RELEVANT_DIGITS 12
+#define MINUNIT_EPSILON (1E-MINUNIT_RELEVANT_DIGITS)
 
 /*  Misc. counters */
 static int minunit_run = 0;
@@ -187,8 +186,8 @@ static void (*minunit_teardown)() = NULL;
 	minunit_assert++;\
 	minunit_tmp_e = (expected);\
 	minunit_tmp_r = (result);\
-	if (fabs(minunit_tmp_e-minunit_tmp_r) > PMIN10(MINUNIT_EPSILON)) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, MINUNIT_EPSILON, minunit_tmp_e, MINUNIT_EPSILON, minunit_tmp_r);\
+	if (fabs(minunit_tmp_e-minunit_tmp_r) > MINUNIT_EPSILON) {\
+		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, MINUNIT_RELEVANT_DIGITS, minunit_tmp_e, MINUNIT_RELEVANT_DIGITS, minunit_tmp_r);\
 		minunit_status = 1;\
 		return;\
 	} else {\

--- a/minunit.h
+++ b/minunit.h
@@ -62,8 +62,10 @@
 
 /*  Maximum length of last message */
 #define MINUNIT_MESSAGE_LEN 1024
-/*  Do not change */
-#define MINUNIT_EPSILON 1E-12
+/*  Accuracy with which floats are compared ( threshold is 10^(-MINUNIT_EPSILON) ) */
+#define MINUNIT_EPSILON 12
+/* Avoid use of pow() function */
+#define PMIN10(X) (1e##-X)
 
 /*  Misc. counters */
 static int minunit_run = 0;
@@ -185,8 +187,8 @@ static void (*minunit_teardown)() = NULL;
 	minunit_assert++;\
 	minunit_tmp_e = (expected);\
 	minunit_tmp_r = (result);\
-	if (fabs(minunit_tmp_e-minunit_tmp_r) > MINUNIT_EPSILON) {\
-		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %g expected but was %g", __func__, __FILE__, __LINE__, minunit_tmp_e, minunit_tmp_r);\
+	if (fabs(minunit_tmp_e-minunit_tmp_r) > PMIN10(MINUNIT_EPSILON)) {\
+		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %.*g expected but was %.*g", __func__, __FILE__, __LINE__, MINUNIT_EPSILON, minunit_tmp_e, MINUNIT_EPSILON, minunit_tmp_r);\
 		minunit_status = 1;\
 		return;\
 	} else {\


### PR DESCRIPTION
Currently, the number of significant figures printed when mu_assert_double_eq fails is undefined. This leads to reports such as: "0.11915440 expected but was 0.11915440" whenever the accuracy in the assert is finer than the significance in printing. 

This code change causes the number of significant figures to vary with the value of MINUNIT_EPSILON. MINUNIT_EPSILON is redefined to be the additive inverse of the exponent. Conversion to 10^(-MINUNIT_EPSILON) is done by the preprocessor (avoiding the use of pow() ).

Examples of the new behavior: 
MINUNIT_EPSILON=4 -> "0.1192 expected but was 0.1194"
MINUNIT_EPSILON=12 -> "0.119154425113 expected but was 0.119354425113"
