### PR TITLE
Setup travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+compiler:
+        - clang
+        - gcc
+env:
+        - CFLAGS="-std=c11"
+        - CFLAGS="-std=c99"
+        - CFLAGS="-std=c89 -pedantic-errors"
+        - CFLAGS="-std=c11 -Wstrict-prototypes"
+os:
+        - linux
+        - osx
+script:
+        (cd ci && make && ./minunit_example)

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,0 +1,14 @@
+CFLAGS += -Wall -Wextra
+INCLUDE_DIRS += -I../
+
+LIBS += -lm
+
+# Os-specific settings
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	LIBS += -lrt
+endif
+
+minunit_example: ../minunit_example.c ../minunit.h
+	$(CC) $(CFLAGS) $(INCLUDE_DIRS) $(LIBS) $< -o $@
+

--- a/minunit.h
+++ b/minunit.h
@@ -262,6 +262,7 @@ static double mu_timer_real(void)
 
 #elif defined(_POSIX_VERSION)
 	/* POSIX. --------------------------------------------------- */
+	struct timeval tm;
 #if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
 	{
 		struct timespec ts;
@@ -291,7 +292,6 @@ static double mu_timer_real(void)
 #endif /* _POSIX_TIMERS */
 
 	/* AIX, BSD, Cygwin, HP-UX, Linux, OSX, POSIX, Solaris. ----- */
-	struct timeval tm;
 	gettimeofday( &tm, NULL );
 	return (double)tm.tv_sec + (double)tm.tv_usec / 1000000.0;
 #else


### PR DESCRIPTION
Initial setup of travis for clang and gcc for linux and mac osx. It covers these configurations:

 * CFLAGS="-std=c11"
 * CFLAGS="-std=c99"
 * CFLAGS="-std=c89 -pedantic-errors"
 * CFLAGS="-std=c11 -Wstrict-prototypes"