### PR TITLE
Change include guards to not use leading underscores

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -20,8 +20,8 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-#ifndef __MINUNIT_H__
-#define __MINUNIT_H__
+#ifndef MINUNIT_MINUNIT_H
+#define MINUNIT_MINUNIT_H
 
 #ifdef __cplusplus
 	extern "C" {
@@ -383,4 +383,4 @@ static double mu_timer_cpu(void)
 }
 #endif
 
-#endif /* __MINUNIT_H__ */
+#endif /* MINUNIT_MINUNIT_H */


### PR DESCRIPTION
Hi everyone,

I'd like to propose changing the include guard identifier to not use a reserved identifier, even though the odds of a problem occurring in practice are low.

Certain identifiers such as those beginning with an underscore and a capital letter or two consecutive underscores are reserved for implementations of C++.

I changed the include guard to use the `project name` + `_` + `file name` format to minimize the chance of a collision.

Thanks,
Greg