### PR TITLE
Add MU_EXIT_CODE for more reliable exit codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ os:
         - linux
         - osx
 script:
-        (cd ci && make && ./minunit_example)
+        (cd ci && make && ./check_example.sh)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a minimal test suite written with minunit:
 	int main(int argc, char *argv[]) {
 		MU_RUN_SUITE(test_suite);
 		MU_REPORT();
-		return minunit_status;
+		return MU_EXIT_CODE;
 	}
 
 Which will produce the following output:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,5 @@ image:
 build_script:
         - cmd: call "C:\\Program Files\\Microsoft SDKs\\Windows\\v7.1\\Bin\\SetEnv.cmd" /x64
         - cmd: call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat" x86_amd64
-        - cmd: cl /EHsc minunit_example.c
+        - cmd: cl /EHsc /DMINUNIT_CI minunit_example.c
         - cmd: minunit_example

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,5 @@ image:
 build_script:
         - cmd: call "C:\\Program Files\\Microsoft SDKs\\Windows\\v7.1\\Bin\\SetEnv.cmd" /x64
         - cmd: call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat" x86_amd64
-        - cmd: cl /EHsc /DMINUNIT_CI minunit_example.c
-        - cmd: minunit_example
+        - cmd: cl /EHsc minunit_example.c
+        - cmd: ci\check_example.bat

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -Wall -Wextra
+CFLAGS += -Wall -Wextra -DMINUNIT_CI
 INCLUDE_DIRS += -I../
 
 LIBS += -lm

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -Wall -Wextra -DMINUNIT_CI
+CFLAGS += -Wall -Wextra
 INCLUDE_DIRS += -I../
 
 LIBS += -lm

--- a/ci/check_example.bat
+++ b/ci/check_example.bat
@@ -1,0 +1,8 @@
+@echo off
+set expected_exit_code=6
+minunit_example
+IF NOT %errorlevel% == %expected_exit_code% (
+  echo Unexpected exit code: %expected_exit_code% expected but was %errorlevel%
+  exit /B 1
+)
+exit /B 0

--- a/ci/check_example.sh
+++ b/ci/check_example.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+expected_exit_code=6
+./minunit_example
+if [ $? -ne $expected_exit_code ]; then
+  echo "Unexpected exit code: $expected_exit_code expected but was $?"
+  exit 1
+fi
+exit 0

--- a/minunit.h
+++ b/minunit.h
@@ -134,6 +134,7 @@ static void (*minunit_teardown)(void) = NULL;
 		minunit_end_real_timer - minunit_real_timer,\
 		minunit_end_proc_timer - minunit_proc_timer);\
 )
+#define MU_EXIT_CODE minunit_fail
 
 /*  Assertions */
 #define mu_check(test) MU__SAFE_BLOCK(\

--- a/minunit_example.c
+++ b/minunit_example.c
@@ -81,6 +81,11 @@ MU_TEST_SUITE(test_suite) {
 int main(int argc, char *argv[]) {
 	MU_RUN_SUITE(test_suite);
 	MU_REPORT();
+#ifdef MINUNIT_CI
+	/* Fake a success exit code for CI builds */
 	return 0;
+#else
+	return MU_EXIT_CODE;
+#endif
 }
 

--- a/minunit_example.c
+++ b/minunit_example.c
@@ -81,11 +81,6 @@ MU_TEST_SUITE(test_suite) {
 int main(int argc, char *argv[]) {
 	MU_RUN_SUITE(test_suite);
 	MU_REPORT();
-#ifdef MINUNIT_CI
-	/* Fake a success exit code for CI builds */
-	return 0;
-#else
 	return MU_EXIT_CODE;
-#endif
 }
 


### PR DESCRIPTION
- Makes it obvious what should be used as an exit code, since before it was easy to get wrong
- `MU_EXIT_CODE` uses `minunit_fail` instead of `minunit_status` because `minunit_status` gets reset to 0 before each test, meaning that any successful test would nullify any preceding failing tests (i.e. 4 failing tests and then a successful test case before exit would cause `minunit_status` to be 0 on exit)
  + Using `minunit_fail` also makes the exit code equal to the number of failing tests
- Updates `minunit_example.c` to use `MU_EXIT_CODE` ~~when not in a CI env~~

---

Minimal example of the `minunit_status` problem:

```c
#include "minunit.h"

MU_TEST(test_fail) {
	mu_fail("Fail now!");
}
MU_TEST(test_success) {
	mu_check(1);
}

int main(int argc, char *argv[]) {
	MU_RUN_TEST(test_fail);
	MU_RUN_TEST(test_success);
	MU_REPORT();
	return minunit_status;
}
```

Because the successful test is run last, `minunit_status` would be 0 on exit. If instead the failure was last, then `minunit_status` would be 1 on exit. With this PR, returning `MU_EXIT_CODE` makes it so the order of the tests doesn't matter--if any test fails, then the exit code will be non-zero.

(see https://github.com/squeek502/d2itemreader/commit/8695e281fd37bfbbc142acdda1dcbf40eeba21f4 for where this was causing false-positives for me)