### PR TITLE
Fix 'ISO C90 does not support __func__' error with GCC 5+

### DIFF
--- a/minunit.h
+++ b/minunit.h
@@ -54,6 +54,10 @@
 #include <mach/mach_time.h>
 #endif
 
+#if __GNUC__ >= 5 && !defined(__STDC_VERSION__)
+#define __func__ __extension__ __FUNCTION__
+#endif
+
 #else
 #error "Unable to define timers for an unknown OS."
 #endif


### PR DESCRIPTION
Travis now uses GCC 5 by default, so the [`-std=c89 -pedantic-errors` job fails](https://travis-ci.org/squeek502/minunit/jobs/614808183) with errors like

```
../minunit.h:143:82: error: ISO C90 does not support ‘__func__’ predefined identifier [-Wpedantic]
 nunit_last_message, MINUNIT_MESSAGE_LEN, "%s failed:\n\t%s:%d: %s", __func__, _
                                                                     ^
```

- Using `__extension__ __FUNCTION__` is what is recommended by https://gcc.gnu.org/gcc-5/porting_to.html
- `__STDC_VERSION__` is not defined by GCC when `-std=c89` is specified