### PR TITLE
Add syntax highlighting to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,62 +14,68 @@ http://www.jera.com/techinfo/jtns/jtn002.html
 
 This is a minimal test suite written with minunit:
 
-	#include "minunit.h"
+```c
+#include "minunit.h"
 
-	MU_TEST(test_check) {
-		mu_check(5 == 7);
-	}
-	MU_TEST_SUITE(test_suite) {
-		MU_RUN_TEST(test_check);
-	}
+MU_TEST(test_check) {
+	mu_check(5 == 7);
+}
+MU_TEST_SUITE(test_suite) {
+	MU_RUN_TEST(test_check);
+}
 
-	int main(int argc, char *argv[]) {
-		MU_RUN_SUITE(test_suite);
-		MU_REPORT();
-		return MU_EXIT_CODE;
-	}
+int main(int argc, char *argv[]) {
+	MU_RUN_SUITE(test_suite);
+	MU_REPORT();
+	return MU_EXIT_CODE;
+}
+```
 
 Which will produce the following output:
 
-	F
-	test_check failed:
-		readme_sample.c:4: 5 == 7
+```
+F
+test_check failed:
+	readme_sample.c:4: 5 == 7
 
 
-	1 tests, 1 assertions, 1 failures
+1 tests, 1 assertions, 1 failures
 
-	Finished in 0.00032524 seconds (real) 0.00017998 seconds (proc)
+Finished in 0.00032524 seconds (real) 0.00017998 seconds (proc)
+```
 
-Check out minunit_example.c to see a complete example. Compile with something
+Check out `minunit_example.c` to see a complete example. Compile with something
 like:
 
-	gcc minunit_example.c -lrt -lm -o minunit_example
+```
+gcc minunit_example.c -lrt -lm -o minunit_example
+```
 
-Don't forget to add -lrt for the timer and -lm for linking the function fabs
-used in mu_assert_double_eq.
+Don't forget to add `-lrt` for the timer and `-lm` for linking the function `fabs`
+used in `mu_assert_double_eq`.
 
 ## Setup and teardown functions
 
 One can define setup and teardown functions and configure the test suite to run
-them by using the macro MU_SUITE_CONFIGURE with within a MU_TEST_SUITE
+them by using the macro `MU_SUITE_CONFIGURE` with within a `MU_TEST_SUITE`
 declaration.
 
 ## Assertion types
 
-mu_check(condition): will pass if the condition is evaluated to true, otherwise
+`mu_check(condition)`: will pass if the condition is evaluated to `true`, otherwise
 it will show the condition as the error message
 
-mu_fail(message): will fail and show the message
+`mu_fail(message)`: will fail and show the message
 
-mu_assert(condition, message): will pass if the condition is true, otherwise it
+`mu_assert(condition, message)`: will pass if the condition is `true`, otherwise it
 will show the failed condition and the message
 
-mu_assert_int_eq(expected, result): it will pass if the two numbers are
+`mu_assert_int_eq(expected, result)`: it will pass if the two numbers are
 equal or show their values as the error message
 
-mu_assert_double_eq(expected, result): it will pass if the two values
+`mu_assert_double_eq(expected, result)`: it will pass if the two values
 are almost equal or show their values as the error message. The value of
-MINUNIT_EPSILON sets the threshold to determine if the values are close enough.
+`MINUNIT_EPSILON` sets the threshold to determine if the values are close enough.
 
 ## Authors
 


### PR DESCRIPTION
I also converted the other two code blocks to use three backticks so that the formatting would be consistent, and I enclosed some things in inline backticks

Original: https://github.com/siu/minunit/blob/master/README.md
With changes: https://github.com/HappyFacade/minunit/blob/patch-1/README.md