### PR TITLE
add mu_assert_long_eq_msg

### DIFF
--- a/ci/check_example.sh
+++ b/ci/check_example.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-expected_exit_code=6
+expected_exit_code=9
 ./minunit_example
 if [ $? -ne $expected_exit_code ]; then
   echo "Unexpected exit code: $expected_exit_code expected but was $?"

--- a/minunit.h
+++ b/minunit.h
@@ -170,6 +170,27 @@ static void (*minunit_teardown)(void) = NULL;
 	}\
 )
 
+#define mu_assert_long_eq_msg(expected, result, msg, ...) MU__SAFE_BLOCK(\
+	long minunit_tmp_e;\
+	long minunit_tmp_r;\
+	minunit_assert++;\
+	minunit_tmp_e = (expected);\
+	minunit_tmp_r = (result);\
+	if (minunit_tmp_e != minunit_tmp_r) {\
+		snprintf(minunit_last_message, MINUNIT_MESSAGE_LEN, \
+			 "%s failed:\n\t%s:%d: %ld expected but was %ld" msg, \
+			 __func__, __FILE__, __LINE__, \
+			 minunit_tmp_e, minunit_tmp_r, ##__VA_ARGS__);\
+		minunit_status = 1;\
+		return;\
+	} else {\
+		printf(".");\
+	}\
+)
+
+#define mu_assert_long_eq(expected, result) \
+	mu_assert_long_eq_msg(expected, result, "")
+
 #define mu_assert_int_eq(expected, result) MU__SAFE_BLOCK(\
 	int minunit_tmp_e;\
 	int minunit_tmp_r;\

--- a/minunit_example.c
+++ b/minunit_example.c
@@ -2,12 +2,14 @@
 
 static int foo = 0;
 static int bar = 0;
+static long lbar = 0;
 static double dbar = 0.1;
 static const char* foostring = "Thisstring";
 
 void test_setup(void) {
 	foo = 7;
 	bar = 4;
+	lbar = 9L;
 }
 
 void test_teardown(void) {
@@ -38,6 +40,22 @@ MU_TEST(test_assert_int_eq_fail) {
 	mu_assert_int_eq(5, bar);
 }
 
+MU_TEST(test_assert_long_eq) {
+	mu_assert_long_eq(9, lbar);
+}
+
+MU_TEST(test_assert_long_eq_fail) {
+	mu_assert_long_eq(5, lbar);
+}
+
+MU_TEST(test_assert_long_eq_fail_msg) {
+	mu_assert_long_eq_msg(5, lbar, ", lbar should be 5\n");
+}
+
+MU_TEST(test_assert_long_eq_fail_msg_args) {
+	mu_assert_long_eq_msg(5, lbar, ", lbar should be %d\n", 5);
+}
+
 MU_TEST(test_assert_double_eq) {
 	mu_assert_double_eq(0.1, dbar);
 }
@@ -65,13 +83,17 @@ MU_TEST_SUITE(test_suite) {
 	MU_RUN_TEST(test_check);
 	MU_RUN_TEST(test_assert);
 	MU_RUN_TEST(test_assert_int_eq);
+	MU_RUN_TEST(test_assert_long_eq);
 	MU_RUN_TEST(test_assert_double_eq);
 
 	MU_RUN_TEST(test_check_fail);
 	MU_RUN_TEST(test_assert_fail);
 	MU_RUN_TEST(test_assert_int_eq_fail);
+	MU_RUN_TEST(test_assert_long_eq_fail);
+	MU_RUN_TEST(test_assert_long_eq_fail_msg);
+	MU_RUN_TEST(test_assert_long_eq_fail_msg_args);
 	MU_RUN_TEST(test_assert_double_eq_fail);
-	
+
 	MU_RUN_TEST(test_string_eq);
 	MU_RUN_TEST(test_string_eq_fail);
 


### PR DESCRIPTION
`mu_assert_long_eq_msg` allows the comparison of two `long`s and optionally add user-defined messages and args to the failure message.

Or shall we can modify existing `mu_assert_XXX_eq`s to allow the passing of user-defined messages by default?